### PR TITLE
Temporarily use ubuntu-22.04 instead of latest in CI

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -7,9 +7,9 @@ concurrency:
 
 jobs:
    tests:
-      name: "ubuntu-latest"
+      name: "ubuntu-22.04"
       timeout-minutes: 60
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-22.04
       strategy:
         fail-fast: false
         matrix:


### PR DESCRIPTION
This is due to ubuntu-latest being updated from ubuntu-22.04 to ubuntu-24.04 and there being different versions of gcc/clang available in ubuntu-24.04 and ubuntu-22.04. See the following for some details.

https://github.com/actions/runner-images/issues/10636

A proper fix to this would be one which installs the relevant versions of gcc/clang in which ever version of ubuntu the runner is using. It's not completely clear to me how to do that at the moment.