### PR TITLE
Remove shadow declarations

### DIFF
--- a/include/hpcombi/epu8.hpp
+++ b/include/hpcombi/epu8.hpp
@@ -36,8 +36,16 @@ eg simde_mm_testz_si128(a,a) → is_all_zero(a) */
 #include "debug.hpp"         // for HPCOMBI_ASSERT
 #include "vect_generic.hpp"  // for VectGeneric
 
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wswitch-default"
+#pragma GCC diagnostic ignored "-Wpacked"
+#endif
 #include "simde/x86/sse4.1.h"  // for simde_mm_max_epu8, simde...
 #include "simde/x86/sse4.2.h"  // for ???
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 namespace HPCombi {
 

--- a/include/hpcombi/perm16.hpp
+++ b/include/hpcombi/perm16.hpp
@@ -39,8 +39,16 @@
 #include "power.hpp"   // for pow
 #include "vect16.hpp"  // for hash, is_partial_permutation
 
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wswitch-default"
+#pragma GCC diagnostic ignored "-Wpacked"
+#endif
 #include "simde/x86/sse4.1.h"
 #include "simde/x86/sse4.2.h"
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 namespace HPCombi {
 

--- a/include/hpcombi/perm16.hpp
+++ b/include/hpcombi/perm16.hpp
@@ -60,7 +60,7 @@ struct alignas(16) PTransf16 : public Vect16 {
 
     PTransf16() = default;
 
-    constexpr PTransf16(const vect v) : Vect16(v) {}
+    constexpr PTransf16(const vect vv) : Vect16(vv) {}
     constexpr PTransf16(const epu8 x) : Vect16(x) {}
     PTransf16(std::vector<uint8_t> dom, std::vector<uint8_t> rng,
               size_t = 0 /* unused */);
@@ -130,8 +130,9 @@ ie as opposed to a permutation, it is not necessarily injective.
 Here n is hard-coded to 16. */
 struct Transf16 : public PTransf16 {
     Transf16() = default;
-    constexpr Transf16(const Transf16 &v) = default;
-    /* implicit */ constexpr Transf16(const vect v) : PTransf16(v) {}  // NOLINT
+    constexpr Transf16(const Transf16 &vv) = default;
+    /* implicit */ constexpr Transf16(const vect vv)  // NOLINT
+        : PTransf16(vv) {}
     /* implicit */ constexpr Transf16(const epu8 x) : PTransf16(x) {}  // NOLINT
     Transf16(std::initializer_list<uint8_t> il) : PTransf16(il) {}
     Transf16 &operator=(const Transf16 &) = default;
@@ -159,8 +160,9 @@ partial means it might not be defined everywhere (but where it's defined, it's
 injective). Undefined images are encoded as 0xFF. */
 struct PPerm16 : public PTransf16 {
     PPerm16() = default;
-    constexpr PPerm16(const PPerm16 &v) = default;
-    /* implicit */ constexpr PPerm16(const vect v) : PTransf16(v) {}  // NOLINT
+    constexpr PPerm16(const PPerm16 &vv) = default;
+    /* implicit */ constexpr PPerm16(const vect vv)  // NOLINT
+        : PTransf16(vv) {}
     /* implicit */ constexpr PPerm16(const epu8 x) : PTransf16(x) {}  // NOLINT
     PPerm16(std::vector<uint8_t> dom, std::vector<uint8_t> rng,
             size_t = 0 /* unused */)
@@ -220,8 +222,8 @@ struct PPerm16 : public PTransf16 {
 struct Perm16 : public Transf16 /* public PPerm : diamond problem */ {
     Perm16() = default;
     constexpr Perm16(const Perm16 &) = default;
-    /* implicit */ constexpr Perm16(const vect v) : Transf16(v) {}  // NOLINT
-    /* implicit */ constexpr Perm16(const epu8 x) : Transf16(x) {}  // NOLINT
+    /* implicit */ constexpr Perm16(const vect vv) : Transf16(vv) {}  // NOLINT
+    /* implicit */ constexpr Perm16(const epu8 x) : Transf16(x) {}    // NOLINT
     Perm16 &operator=(const Perm16 &) = default;
     Perm16(std::initializer_list<uint8_t> il) : Transf16(il) {}
 


### PR DESCRIPTION
This commit renames some of the variables from the constructors of PTransf16 and its derived classes from "v" to "vv". The reason for doing this is that there is a data member of Vect16 named "v", and compiling with warnings enabled complains that the variables "v" shadowed the data member "v".